### PR TITLE
Grammar fix in info.md file

### DIFF
--- a/info.md
+++ b/info.md
@@ -41,7 +41,7 @@ Other Plugins
 
 ### Support
 
-* [Github Issues](https://github.com/jeremylong/DependencyCheck/issues)
+* [GitHub Issues](https://github.com/jeremylong/DependencyCheck/issues)
 
 ### Presentation
 


### PR DESCRIPTION
I've changed lowercase "h" to an uppercase "H" in the word, "GitHub".